### PR TITLE
Added error handling to extract full script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ logs/
 .coverage
 utils/.coverage
 .DS_Store
+test_logs


### PR DESCRIPTION
Changed ENV to ENV.get() - results to default and returns None - handles missing variables gracefully
 
Added error handling for `download_wcd_google_sheet`:
* Empty google sheet URL given
* Missing google sheet path env variables
* Added a check to ensure there are rows beyond the headers.
* FileNotFound error
 
Added error handling for `download_vg_sales_kaggle`:
* Put `os.listdir(dataset_folder_path)` into a variable
* Ensures the Kaggle dataset folder is not empty before proceeding

Updated `test_extract_full.py` to ensure it tests for error handling cases and that the function handles errors correctly.

This closes #4 